### PR TITLE
fixed bug for requests under /classificationGame/.... used to give 404

### DIFF
--- a/edition-ldod/src/main/java/pt/ist/socialsoftware/edition/ldod/controller/ClassificationGameHomeController.java
+++ b/edition-ldod/src/main/java/pt/ist/socialsoftware/edition/ldod/controller/ClassificationGameHomeController.java
@@ -19,7 +19,7 @@ public class ClassificationGameHomeController {
         return LdoDSession.getLdoDSession();
     }
 
-    @RequestMapping(method = RequestMethod.GET, value = "/classification-game")
+    @RequestMapping(method = RequestMethod.GET, value = {"/classification-game", "/classification-game/*"})
     public String showHome(Model model) {
         return "classificationGame";
     }


### PR DESCRIPTION
Small bug that if user inserted directly urls such as **https://ldod.uc.pt/classification-game/login** it would return 404 or if inside the game environment opened a new tab it would give 404.
Controller now accepts these requests and redirects accordingly